### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-crispy-forms==2.3
 crispy-bootstrap5==2024.2
 django-theme-pixel==1.0.3
 django-tinymce==4.1.0
+django-cors-headers==4.6.0
 
 # Deployment
 whitenoise==6.7.0

--- a/xss_attempts.log
+++ b/xss_attempts.log
@@ -1,4 +1,0 @@
-List of latest XSS attacks detection: 
-List of latest XSS attacks detection: 
-List of latest XSS attacks detection: 
-List of latest XSS attacks detection: 


### PR DESCRIPTION
![Screenshot (1998)](https://github.com/user-attachments/assets/5c7af2c0-63a3-4091-9868-03bad2fa1ec4)

I included the django-cors-headers version because the CORS module was not specified when I tried opening the entire web application.