### PR TITLE
Updating requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ Pillow==11.0.0
 bcrypt==4.2.1
 
 # CAPTCHA
-django-simple-captcha==0.5.15
+django-simple-captcha==0.6.0
 
 
 djangorestframework==3.15.2


### PR DESCRIPTION
Hey Sam, due to the change of version of pillow library in the requirements.txt after all the merges, the captcha library needed the newer version as well. This commit fixes that issue.