### PR TITLE
fixed navigation bar at the top

### DIFF
--- a/custom_static/css/hardhat.css
+++ b/custom_static/css/hardhat.css
@@ -21852,7 +21852,7 @@ fieldset:disabled .btn {
   background-color: var(--navbar-light);
   justify-content: center;
   align-items: center;
-  position: absolute;
+  position: fixed;
   top: 0;
   width: 100%;
   z-index: 100;


### PR DESCRIPTION
The navigation bar had a bug where it wasn't static across all pages (both top and bottom). I fixed the bug, and now the navigation bar remains static on all pages, including while scrolling