### PR TITLE
Fix dark mode toggle for responsive navbar

### DIFF
--- a/custom_static/css/hardhat.css
+++ b/custom_static/css/hardhat.css
@@ -27231,3 +27231,23 @@ blockquote {
 }
 
 }
+
+
+/* Force dark mode background on mobile navbar when collapsed */
+body.dark-mode .navbar-collapse.show {
+  background-color: #333333 !important;
+}
+
+body.dark-mode .navbar-collapse.show a,
+body.dark-mode .navbar-collapse.show label,
+body.dark-mode .navbar-collapse.show .nav-link {
+  color: #ffffff !important;
+}
+
+/* Immediate dark background for collapsed navbar in dark mode */
+@media (max-width: 991.98px) {
+  body.dark-mode .navbar-collapse {
+    background-color: #222 !important;
+    transition: none !important;
+  }
+}

--- a/custom_static/js/toggles.js
+++ b/custom_static/js/toggles.js
@@ -1,27 +1,27 @@
 document.addEventListener('DOMContentLoaded', function () {
-    const toggleButton = document.getElementById('darkModeButton');
+    const toggleButton = document.getElementById('darkModeButton'); // top right sun/moon button
     const icon = document.getElementById('darkModeIcon');
     const navbar = document.querySelector('.navbar-main');
     const dropdownMenus = document.querySelectorAll('.dropdown-menu');
     const whiteboardContainers = document.querySelectorAll('.whiteboard-container');
 
+    const mobileToggle = document.getElementById('darkmode-toggle'); // sidebar switch
+
     const darkMode = localStorage.getItem('darkMode') === 'true';
     applyDarkMode(darkMode);
 
+    // Apply mode change visually
     function applyDarkMode(isDark) {
         document.body.classList.toggle('dark-mode', isDark);
-        toggleButton.style.backgroundColor = isDark ? '#333333' : '#f0f0f0';
+        if (toggleButton) toggleButton.style.backgroundColor = isDark ? '#333333' : '#f0f0f0';
 
-        if (isDark) {
-            icon.classList.remove('fa-sun');
-            icon.classList.add('fa-moon');
-        } else {
-            icon.classList.remove('fa-moon');
-            icon.classList.add('fa-sun');
+        if (icon) {
+            icon.classList.remove(isDark ? 'fa-sun' : 'fa-moon');
+            icon.classList.add(isDark ? 'fa-moon' : 'fa-sun');
+            icon.style.color = '#ffcd11';
         }
 
-        icon.style.color = '#ffcd11';
-        navbar.style.backgroundColor = isDark ? '#333333' : '#ffffff';
+        if (navbar) navbar.style.backgroundColor = isDark ? '#333333' : '#ffffff';
 
         dropdownMenus.forEach(menu => {
             menu.style.backgroundColor = isDark ? '#333333' : '#ffffff';
@@ -33,11 +33,26 @@ document.addEventListener('DOMContentLoaded', function () {
             container.style.color = isDark ? '#ffffff' : '#000000';
         });
 
+        // Sync both toggle switches
+        if (mobileToggle) mobileToggle.checked = isDark;
     }
 
-    toggleButton.addEventListener('click', function () {
-        const isDark = !document.body.classList.contains('dark-mode');
-        localStorage.setItem('darkMode', isDark.toString());
-        applyDarkMode(isDark);
-    });
+    // Desktop toggle button
+    if (toggleButton) {
+        toggleButton.addEventListener('click', function () {
+            const isDark = !document.body.classList.contains('dark-mode');
+            localStorage.setItem('darkMode', isDark.toString());
+            applyDarkMode(isDark);
+        });
+    }
+
+    // Mobile sidebar toggle
+    if (mobileToggle) {
+        mobileToggle.addEventListener('change', function () {
+            const isDark = mobileToggle.checked;
+            localStorage.setItem('darkMode', isDark.toString());
+            applyDarkMode(isDark);
+        });
+    }
 });
+    


### PR DESCRIPTION
**Student Name:** 
Ehsen Wahab Tahir

**Task Description:**
This pull request addresses a visual and functional issue related to the dark mode toggle in the responsive view of the Hardhat website. When the site was viewed on smaller screen sizes or zoomed out enough to activate the mobile sidebar, the dark mode toggle did not reflect the correct mode.

**What I Did:**

- **Added JavaScript in toggle.js to:**

- Detect saved dark mode preference via localStorage and apply it on page load.

- Use document.body.classList.toggle('dark-mode', isDark) to control theme application.
 
- Sync the top-right desktop toggle and sidebar checkbox toggle so they reflect each other.
 
- Use query selectors to apply theme colors to .navbar, .dropdown-menu, and .whiteboard-container.

- Ensured the dark mode state is persistent across reloads and resizes.

- **Updated the CSS (hardhat.css) to:**
 
- Force correct background and text color on .navbar-collapse when in dark mode.

- Remove any unwanted shaded overlay or flash when the sidebar opens.


**Screenshots:**


![image](https://github.com/user-attachments/assets/6baba274-bed4-4c6c-a950-546cca06060a)


![image](https://github.com/user-attachments/assets/55c4cd5e-5dcc-4b87-81fd-4fc37ba18061)


![image](https://github.com/user-attachments/assets/9169258f-427d-43e4-a635-3fd4fc7bc6a7)


![image](https://github.com/user-attachments/assets/ead3466c-ef1d-4a89-84fa-317948e9bd30)
