### PR TITLE
added postgresql 17.5 to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,5 @@ COPY . .
 # Create necessary directories
 RUN mkdir -p /app/static /app/media
 
-# Run migrations
-RUN python manage.py migrate
-
 # Run gunicorn
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "core.wsgi"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,64 @@
-version: '3.8'
-
 services:
+  db:
+    container_name: postgres_db
+    image: postgres:17.5
+    restart: always
+    environment:
+      POSTGRES_DB: hardhat_db
+      POSTGRES_USER: hardhat_user
+      POSTGRES_PASSWORD: hardhat_password
+      # PostgreSQL 17.5
+      POSTGRES_INITDB_ARGS: "--auth-host=md5 --auth-local=trust"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      #note postgresql can be optimised by adding a custom config file
+    networks:
+      - web_network
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hardhat_user -d hardhat_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   web:
     container_name: django_app
     build: .
     restart: always
     volumes:
-      - .:/app  # Mount project code
-      - staticfiles:/app/static
+      - .:/app
+      - staticfiles:/app/static #collectstatic will only collect static folder so needs to be created from custom_static folder
       - mediafiles:/app/media
       # Keep custom_static mount if you have static files there
-      - ./custom_static:/app/custom_static 
+      - ./custom_static:/app/custom_static
     networks:
       - web_network
     environment:
       - DEBUG=0
+      - DB_ENGINE=postgresql
+      - DB_NAME=hardhat_db
+      - DB_USERNAME=hardhat_user
+      - DB_PASS=hardhat_password
+      - DB_HOST=db
+      - DB_PORT=5432
     expose:
       - "8000:80"
-    # Run collectstatic and migrate before starting gunicorn
+    depends_on:
+      db:
+        condition: service_healthy
+    # Wait for database to install then run migrations and start server
     command: >
-      sh -c "python manage.py migrate && 
+      sh -c "echo 'Waiting for database...' &&
+             until python -c 'import psycopg2; psycopg2.connect(host=\"db\", port=5432, user=\"hardhat_user\", password=\"hardhat_password\", database=\"hardhat_db\")' 2>/dev/null; do
+               echo 'Database is unavailable - sleeping';
+               sleep 2;
+             done &&
+             echo 'Database is ready!' &&
+             python manage.py migrate &&
              python manage.py collectstatic --noinput --clear &&
-             gunicorn --bind 0.0.0.0:8000 core.wsgi"
+             gunicorn --bind 0.0.0.0:8000 --workers 3 --timeout 120 core.wsgi"
 
   nginx:
     container_name: nginx
@@ -39,6 +76,12 @@ services:
       - web_network
     depends_on:
       - web
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
 networks:
   web_network:
@@ -48,4 +91,4 @@ networks:
 volumes:
   staticfiles: {}
   mediafiles: {}
- 
+  postgres_data: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,9 @@ crispy-bootstrap5==2024.2
 django-theme-pixel==1.0.3
 django-tinymce==4.1.0
 
+# Database
+psycopg2-binary==2.9.9
+
 # Deployment
 whitenoise==6.7.0
 gunicorn==23.0.0


### PR DESCRIPTION
Bryce Bacon

Docker container now uses postgreSQL instead of sqllite. Python manage.py runserver will still use sqlLite. (though we are trying to drop this as development method)

1. Run docker compose up --build 
2. website should run normally
3. check terminal to show postgres running correctly

<img width="798" height="867" alt="Screenshot 2025-07-31 at 2 16 49 PM" src="https://github.com/user-attachments/assets/68f6f264-37a3-4ac7-8120-418e97eed041" />
