### PR TITLE
CI: fix i18n workflow by installing python-dotenv

### DIFF
--- a/.github/workflows/i18n-auto.yml
+++ b/.github/workflows/i18n-auto.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          pip install Django polib deepl
+          pip install -r requirements.txt
+          pip install polib deepl
 
       - name: Make messages (django & djangojs)
         run: |


### PR DESCRIPTION
Xibei Cheng (Chloe) 222113273

After PR#350 was merged, the i18n GitHub Actions workflow failed because 
`python-dotenv` was not installed in the CI environment. This caused 
`makemessages` to throw a ModuleNotFoundError when loading settings.py.

This PR updates `.github/workflows/i18n-auto.yml` to install dependencies 
from `requirements.txt` (which already includes python-dotenv), and ensures 
that all required packages are available before running makemessages.

Merging this fix will prevent other developers from encountering errors 
when pulling the latest changes and running the project or CI.

<img width="973" height="531" alt="1" src="https://github.com/user-attachments/assets/edf4f7ae-9399-45df-acca-c11d3febb656" />
<img width="1036" height="644" alt="2" src="https://github.com/user-attachments/assets/f8d3eca9-536a-404a-a0ca-43357118bcd6" />
<img width="494" height="412" alt="3" src="https://github.com/user-attachments/assets/57e748ba-f663-4d19-9d30-9dfc21c92fde" />


