### PR TITLE
CI (i18n): fix i18n workflow by newline normalization & safe DeepL handling

### DIFF
--- a/.github/workflows/i18n-auto.yml
+++ b/.github/workflows/i18n-auto.yml
@@ -2,6 +2,8 @@ name: i18n-auto-translate
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch: {}
 
 jobs:
@@ -27,29 +29,65 @@ jobs:
 
       - name: Make messages (django & djangojs)
         run: |
-          python manage.py makemessages -l zh_Hans -l fr -l es -l ja -l ko
-          python manage.py makemessages -l zh_Hans -l fr -l es -l ja -l ko -d djangojs
+          python manage.py makemessages --no-wrap -l zh_Hans -l fr -l es -l ja -l ko
+          python manage.py makemessages --no-wrap -l zh_Hans -l fr -l es -l ja -l ko -d djangojs
 
       - name: Auto translate (DeepL)
+        if: ${{ github.event_name != 'pull_request' && secrets.DEEPL_API_KEY != '' }}
         env:
           DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
         run: |
           python manage.py auto_translate_messages --locale_dir=locale
 
+      - name: Skip DeepL (PR build or no secret)
+        if: ${{ github.event_name == 'pull_request' || secrets.DEEPL_API_KEY == '' }}
+        run: echo "Skipping DeepL (pull_request build or no DEEPL_API_KEY)."
+
+      - name: Normalize PO newline parity
+        run: |
+          python - <<'PY'
+          import polib, pathlib
+          base = pathlib.Path("locale")
+          for po_path in base.rglob("*/LC_MESSAGES/*.po"):
+              po = polib.pofile(str(po_path))
+              changed = False
+              def align(msgid, s):
+                  if s is None: return s
+                  out = s
+                  if msgid.startswith('\n') and not out.startswith('\n'): out = '\n' + out
+                  if not msgid.startswith('\n') and out.startswith('\n'): out = out.lstrip('\n')
+                  if msgid.endswith('\n') and not out.endswith('\n'): out = out + '\n'
+                  if not msgid.endswith('\n') and out.endswith('\n'): out = out.rstrip('\n')
+                  return out
+              for e in po:
+                  if e.msgstr:
+                      e.msgstr = align(e.msgid, e.msgstr); changed = True
+                  if e.msgstr_plural:
+                      for k,v in e.msgstr_plural.items():
+                          e.msgstr_plural[k] = align(e.msgid, v); changed = True
+              if changed:
+                  po.save(str(po_path))
+          PY
+
       - name: Compile messages
         run: |
-          django-admin compilemessages
+          python manage.py compilemessages \
+            -l zh_Hans -l fr -l es -l ja -l ko \
+            -i venv -i .git -i node_modules -i "**/site-packages/**"
 
-      - name: Commit & Create PR
+      - name: Commit & Create PR (from main push)
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           git config user.name "i18n-bot"
           git config user.email "i18n-bot@example.com"
           branch="chore/i18n-auto-$(date +%Y%m%d%H%M)"
           git checkout -b "$branch"
           git add locale/**/LC_MESSAGES/*.po locale/**/LC_MESSAGES/*.mo
-          git commit -m "chore(i18n): auto-translate via DeepL & compile"
+          git commit -m "chore(i18n): auto-translate & normalize & compile"
           git push -u origin "$branch"
+          
       - uses: peter-evans/create-pull-request@v6
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           title: "chore(i18n): auto-translate via DeepL"
           body: "Automated pipeline. No manual msgstr. Languages: zh_Hans, fr, es, ja, ko."


### PR DESCRIPTION
Chloe Cheng 222113273



After PR#367 was merged, the i18n workflow still failed at the compilemessages step.
msgfmt reported fatal errors because some .po entries had inconsistent leading/trailing newlines between msgid and msgstr, often introduced by auto-translation.
PR builds from forks also failed when the DeepL secret was unavailable.
<img width="681" height="140" alt="image" src="https://github.com/user-attachments/assets/5de53a1e-4f92-4ed8-abbe-66138b6fc31a" />
<img width="1207" height="527" alt="image" src="https://github.com/user-attachments/assets/62bc710d-6107-4249-bf75-b8d3803627d0" />


**Fixes in this PR**

- Added a normalization step to align newlines in all .po files before compilation.

- Switched makemessages to use --no-wrap to reduce unnecessary diffs caused by line wrapping.

- Updated auto_translate_messages.py

- Modified workflow to:

  - Run DeepL only on non-PR builds when DEEPL_API_KEY is set.

  - Gracefully skip DeepL for fork PRs or missing secret, avoiding false CI failures.

- Changed compile step for better reliability.

**Verification**

- Reproduced the full GitHub Actions environment locally using Docker (python:3.11-slim).

- Ran the entire pipeline end-to-end with DeepL enabled: no errors.
<img width="1920" height="1040" alt="2" src="https://github.com/user-attachments/assets/59a1fc43-7878-4aa5-b09b-ef3babf736b8" />


**Impact**

- Stabilizes the i18n auto-translate workflow.

- Keeps main branch CI green.

- Prevents repeated failures on PRs from forks