### PR TITLE
CI: fix i18n workflow secrets handling and normalize PO newlines

### DIFF
--- a/.github/workflows/i18n-auto.yml
+++ b/.github/workflows/i18n-auto.yml
@@ -1,7 +1,8 @@
 name: i18n-auto-translate
+
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/**, chore/** ]
   pull_request:
     branches: [ main ]
   workflow_dispatch: {}
@@ -9,9 +10,14 @@ on:
 jobs:
   i18n:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
 
       - name: Install gettext
         run: |
@@ -19,7 +25,8 @@ jobs:
           sudo apt-get install -y gettext
 
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
 
       - name: Install Python deps
         run: |
@@ -32,15 +39,22 @@ jobs:
           python manage.py makemessages --no-wrap -l zh_Hans -l fr -l es -l ja -l ko
           python manage.py makemessages --no-wrap -l zh_Hans -l fr -l es -l ja -l ko -d djangojs
 
+      - name: Decide whether DeepL is available
+        id: deepl_guard
+        env:
+          HAS_DEEPL: ${{ secrets.DEEPL_API_KEY != '' }}
+        run: |
+          echo "has_deepl=${HAS_DEEPL}" >> "$GITHUB_OUTPUT"
+
       - name: Auto translate (DeepL)
-        if: ${{ github.event_name != 'pull_request' && secrets.DEEPL_API_KEY != '' }}
+        if: ${{ github.event_name != 'pull_request' && steps.deepl_guard.outputs.has_deepl == 'true' }}
         env:
           DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
         run: |
           python manage.py auto_translate_messages --locale_dir=locale
 
       - name: Skip DeepL (PR build or no secret)
-        if: ${{ github.event_name == 'pull_request' || secrets.DEEPL_API_KEY == '' }}
+        if: ${{ !(github.event_name != 'pull_request' && steps.deepl_guard.outputs.has_deepl == 'true') }}
         run: echo "Skipping DeepL (pull_request build or no DEEPL_API_KEY)."
 
       - name: Normalize PO newline parity
@@ -85,7 +99,7 @@ jobs:
           git add locale/**/LC_MESSAGES/*.po locale/**/LC_MESSAGES/*.mo
           git commit -m "chore(i18n): auto-translate & normalize & compile"
           git push -u origin "$branch"
-          
+
       - uses: peter-evans/create-pull-request@v6
         if: ${{ github.ref == 'refs/heads/main' }}
         with:


### PR DESCRIPTION
Chloe Cheng 222113273
This PR fixes the i18n GitHub Actions workflow so that it runs correctly both on branches and on pull requests.

### Changes
- Refactored `.github/workflows/i18n-auto.yml`:
  - Removed direct `secrets.DEEPL_API_KEY` usage in `if:` expressions (causing "Unrecognized named-value: secrets" error).
  - Added a guard step (`deepl_guard`) to safely detect whether DeepL secret is available.
  - Adjusted conditions:
    - On branch pushes (with secrets), DeepL auto-translation runs.
    - On PR builds or no secret, DeepL step is skipped but `makemessages`, normalization, and `compilemessages` still run.
  - Kept `main` branch push logic: auto-create PR with translated `.po/.mo` files.

- Verified workflow on branch `chore/ci-i18n-normalize`:
  - Successfully executed DeepL translation step when secrets are available.
  - Properly skipped translation in PR-like contexts.
  - No more parsing errors and workflow graph displays correctly.
  
<img width="1920" height="953" alt="successful workflow" src="https://github.com/user-attachments/assets/0eee3e7c-3940-4864-8ab7-112ff233ede2" />
<img width="1920" height="953" alt="successful workflow2" src="https://github.com/user-attachments/assets/51998e4d-669b-4a49-907e-fe30c1938db8" />


### Reason
Previously, the workflow failed to parse when checking secrets in `if:` conditions, blocking all i18n automation.  
This update stabilizes the pipeline and ensures i18n auto-translate works reliably.

