### PR TITLE
Fixed navbar and CSS styles

### DIFF
--- a/custom_static/css/hardhat.css
+++ b/custom_static/css/hardhat.css
@@ -5736,14 +5736,29 @@ fieldset:disabled .btn {
 
 .menu-link {
   width: 100% !important;
+   color: #ffcd11 !important;
+  text-decoration: none;
+  display: block;
+  padding: 12px 20px;
+  transition: all 0.2s ease-in-out;
+  font-weight: 600;
 }
+.menu-link:hover {
+  color: #fff !important;
+  text-decoration: none;
+}
+
+
 .menu:hover {
   background: #ffcd11 !important;
   font-weight: 600;
   transition: all 0.2s ease-in-out;
-  color: white !important;
-  transition: all 0.2s ease-in-out;
+  color: #fff !important;
 }
+.menu:hover .menu-link {
+  color: #fff !important;
+}
+
 
 .menu {
   font-size: 14px;
@@ -5775,6 +5790,26 @@ fieldset:disabled .btn {
 .dark-mode .dropdown-menu {
   background-color: var(--navbar-dark);
 }
+
+.dark-mode .menu-link {
+  color: #ffcd11 !important;
+}
+.dark-mode .menu-link:hover {
+  color: #fff !important;
+}
+.dark-mode .menu:hover .menu-link {
+  color: #fff !important;
+}
+
+#blogDropdown + .dropdown-menu {
+  padding: 40px 24px;
+}
+
+#blogDropdown + .dropdown-menu .menu {
+  margin: 8px 0;
+  border-radius: 0;
+}
+
 
 .dropdown-menu[data-bs-popper] {
   top: 100%;

--- a/home/templates/accounts/sign-up-client.html
+++ b/home/templates/accounts/sign-up-client.html
@@ -1,4 +1,11 @@
-{% extends 'layouts/base.html' %} {% load static %} {% block header %} {%include 'includes/navigation.html'%} {% endblock header %} {% block content %}
+{% extends 'layouts/base.html' %}
+{% load static %}
+
+{% block header %}
+  {% include 'includes/navigation.html' %}
+{% endblock header %}
+
+{% block content %}
 
 <main>
   {% include 'includes/pre-loader.html' %}
@@ -288,4 +295,5 @@
 </style>
 
 {% endblock content %}
+
 {% block footer %}{% endblock footer %}

--- a/home/templates/accounts/sign-up.html
+++ b/home/templates/accounts/sign-up.html
@@ -1,5 +1,11 @@
-{% extends 'layouts/base.html' %} {% load static %} {% block header %} {%
-include 'includes/navigation.html' %} {% endblock header %} {% block content %}
+{% extends 'layouts/base.html' %}
+{% load static %}
+
+{% block header %}
+  {% include 'includes/navigation.html' %}
+{% endblock header %}
+
+{% block content %}
 
 <style>
   /* Form Control Styling */
@@ -689,4 +695,6 @@ include 'includes/navigation.html' %} {% endblock header %} {% block content %}
   }
 </style>
 
-{% endblock content %} {% block footer %}{% endblock footer %}
+{% endblock content %}
+
+{% block footer %}{% endblock footer %}


### PR DESCRIPTION
Issue: The styles and sign-up page navigation bar were not loading because the Django template tags were improperly formatted and the imports of the resources were duplicated creating template parsing error and resource conflicts.
Solution: Template structure was correctly formatted with proper spacing and line breaks and any duplicated CSS imports were eliminated in the base template, so that navigation is rendered properly and styles are loaded without conflicts.
<img width="1919" height="1074" alt="navbar problem" src="https://github.com/user-attachments/assets/f047a42b-7efa-459a-8a55-d9828fcbb0dc" />
<img width="1919" height="1079" alt="navbar solution" src="https://github.com/user-attachments/assets/e4bac587-4232-4583-82df-9fee24cbeded" />


Problem: Trouble with the blog dropdown because the menu items were invisible by default. You had to hover over them to see what was actually there, which made the navigation confusing and hard to use.
Solution: Added the proper color styling that was missing, so now the dropdown text is always visible and works consistently in both light and dark modes.

<img width="1919" height="1078" alt="hover problem" src="https://github.com/user-attachments/assets/a9b64b32-5f10-40b3-92c7-6920f731036d" />
<img width="1919" height="1079" alt="hover solution" src="https://github.com/user-attachments/assets/2fc2a53e-bebc-4bdf-b5ca-daf87ad3e631" />

