### PR TITLE
Add feature: WeakPatternValidator to prevent repeats and sequences; u…

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -245,15 +245,25 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 
     {
-    "NAME": "home.validators.ComplexityPasswordValidator",
-    "OPTIONS": {
-        "require_lower": True,
-        "require_upper": True,
-        "require_digit": True,
-        "require_symbol": True,
-        "symbols": r"[@$!%*?&]",
+        "NAME": "home.validators.ComplexityPasswordValidator",
+        "OPTIONS": {
+            "require_lower": True,
+            "require_upper": True,
+            "require_digit": True,
+            "require_symbol": True,
+            "symbols": r"[@$!%*?&]",
+        },
     },
-},
+
+    # Common Patterns (Sequences & Repeats)
+    {
+        "NAME": "home.validators.WeakPatternValidator",
+        "OPTIONS": {
+            "min_sequence_len": 3,  # reject 3+ like 123/abc/qwe
+            "min_repeat_len": 3,    # reject aaa/111/!!!
+            "keyboard_sequences": ["qwe", "asd", "zxc", "rty"],
+        },
+    },
     
     # Prevent reusing last N passwords
     {

--- a/home/templates/accounts/sign-in.html
+++ b/home/templates/accounts/sign-in.html
@@ -63,7 +63,7 @@
                                         Remember me
                                     </label>
                                 </div>
-                                <div><a href="{% url 'password_reset' %}" class="small text-right lost-password">Lost password?</a></div>
+                                <div><a href="{% url 'password_reset' %}" class="small text-right lost-password">Forgot Password?</a></div>
                             </div>
                             <div class="d-grid">
                                 <button type="submit" class="btn btn-warning btn-primary">Sign in</button>


### PR DESCRIPTION
Student Name: 
Abdulrahman Saleh M Alghaith

Task Description:
Implement a custom password validator to reject weak common patterns (sequences and repeats) that pass basic complexity rules, and update the sign-in page text.

What I Did:

- Added a new WeakPatternValidator in validators.py to block weak password patterns such as repeats of length ≥3 (aaa, 111), ascending sequences (abc, 1234), and common keyboard runs (qwe, asd). 

- Registered the validator in settings.py so it applies across all password flows.

- Updated the sign-in page link text by changing "Lost password?" to "Forgot Password?".

Screenshot:

<img width="214" height="338" alt="image" src="https://github.com/user-attachments/assets/ef816339-7bc8-42ef-8764-224496513680" />

<img width="234" height="311" alt="image" src="https://github.com/user-attachments/assets/78b0d330-27af-4632-b296-e9b9a01fa7fa" />

<img width="234" height="292" alt="image" src="https://github.com/user-attachments/assets/d6efd545-45e4-472e-90d0-bdb450280c9f" />

